### PR TITLE
added padding at the bottom of the translationHelps component 

### DIFF
--- a/css/style.js
+++ b/css/style.js
@@ -5,7 +5,8 @@ var style = {
     padding: '9px',
     minHeight: "100%",
     maxHeight: "100%",
-    backgroundColor: "#e7e7e7"
+    backgroundColor: "#e7e7e7",
+    paddingBottom: "100px"
   },
   tHGlyphicon: {
     float: "right",


### PR DESCRIPTION

#### This pull request addresses:
Added padding at bottom of tHelps to allow readability.

- The Help sidebar is too long for laptop screens #1277


#### How to test this pull request:
open tC and in the tHelps section scroll all the way down. now you should be able to read the entire text in tHelps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationhelps/19)
<!-- Reviewable:end -->
