### PR TITLE
fix for thelps window scrolling to top when new topic displayed

### DIFF
--- a/View.js
+++ b/View.js
@@ -11,8 +11,12 @@ class TranslationHelpsDisplay extends React.Component {
   render() {
     let { currentFile, modalFile } = this.props;
     if (currentFile) {
+      var page = document.getElementById("helpsbody");
+      if (page) {
+        page.scrollTop = 0;
+      }
       return (
-        <div style={style.translationHelpsContent}>
+        <div id="helpsbody" style={style.translationHelpsContent}>
           <style dangerouslySetInnerHTML={{
             __html: [
               '.remarkableStyling h1{',


### PR DESCRIPTION
#### This pull request addresses:

issue #1423



#### How to test this pull request:

Open a project, go to a check with a long thelps...scroll to the bottom of the thelps.  Now go to another check with a long thelps.  It should scroll back to the top, instead of staying scrolled to the bottom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationhelps/35)
<!-- Reviewable:end -->
