### PR TITLE
updated tHelps to full flex

### DIFF
--- a/View.js
+++ b/View.js
@@ -16,7 +16,7 @@ class TranslationHelpsDisplay extends React.Component {
         page.scrollTop = 0;
       }
       return (
-        <div id="helpsbody" style={style.translationHelpsContent}>
+        <div style={{flex: 'auto', display: 'flex'}}>
           <style dangerouslySetInnerHTML={{
             __html: [
               '.remarkableStyling h1{',
@@ -45,17 +45,21 @@ class TranslationHelpsDisplay extends React.Component {
             ].join('\n')
           }}>
           </style>
-          <div onClick={this.props.showModal}>
-            <Glyphicon glyph={"fullscreen"} title="Click to show expanded helps"
-              style={style.tHGlyphicon} />
+          <div style={style.helpsContent}>
+            <div style={style.helpsHeader}>
+              <Glyphicon glyph={"fullscreen"}
+                         title="Click to show expanded helps"
+                         onClick={this.props.showModal}
+                         style={style.helpsIcon} />
+            </div>
+            <div id="helpsbody" className="remarkableStyling" style={style.helpsBody}>
+              <Markdown options={{ html: true }} source={currentFile} />
+            </div>
           </div>
           <THelpsModal show={this.props.modalVisibility}
             onHide={this.props.hideModal}>
             <Markdown options={{ html: true }} source={modalFile} />
           </THelpsModal>
-          <div className="remarkableStyling">
-            <Markdown options={{ html: true }} source={currentFile} />
-          </div>
         </div>
       );
     }

--- a/css/style.js
+++ b/css/style.js
@@ -1,13 +1,24 @@
 var style = {
-  translationHelpsContent: {
-    overflowY: "auto",
-    minWidth: "100%",
-    padding: '30px 15px 50px',
-    height: "calc(100% - 30px)",
+  helpsContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 'auto',
     backgroundColor: "var(--background-color-light)"
   },
-  tHGlyphicon: {
-    float: "right",
+  helpsHeader: {
+    flex: '0 0 50px',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+    padding: '0 15px',
+    borderBottom: '1px solid var(--border-color)',
+  },
+  helpsBody: {
+    flex: 'auto',
+    overflowY: "auto",
+    padding: '0 15px 30px',
+  },
+  helpsIcon: {
     color: "var(--text-color)",
     fontSize: "20px",
     cursor: "pointer"


### PR DESCRIPTION
#### This pull request addresses:

Updated flex layout based on issues found in #1645.  Thelps pane no longer shifts sizes and now check area takes up the space when tHelps is collapsed.  Must pull in all three PR's for it to work (tHelps, Notes and Words)



#### How to test this pull request:

Include testing instructions so that other developers know what to look for, and how to make sure that your feature/bugfix/enhancement really works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationhelps/36)
<!-- Reviewable:end -->
