### PR TITLE
Conditionally scroll when content changes

### DIFF
--- a/View.js
+++ b/View.js
@@ -5,13 +5,17 @@ import THelpsModal from './components/THelpsModal';
 import style from './css/style';
 
 class TranslationHelpsDisplay extends React.Component {
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.currentFile !== nextProps.currentFile) {
+      var page = document.getElementById("helpsbody");
+      if (page) page.scrollTop = 0;
+    }
+  }
+
   render() {
     let { currentFile, modalFile } = this.props;
     if (currentFile) {
-      var page = document.getElementById("helpsbody");
-      if (page) {
-        page.scrollTop = 0;
-      }
       return (
         <div style={{flex: 'auto', display: 'flex'}}>
           <style dangerouslySetInnerHTML={{


### PR DESCRIPTION
#### This pull request addresses:

Scrolling to Top is now only happening when content changes, not on every render.


#### How to test this pull request:

- Open a project/tool
- scroll tH to lower part
- open modal for tH, it shouldn't scroll to top
- close modal, shouldn't scroll to top
- change check in same group, shouldn't scroll to top
- change check to another group, should scroll to top

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationhelps/43)
<!-- Reviewable:end -->
