### PR TITLE
Fixed THelps Width On Window Resize

### DIFF
--- a/css/style.js
+++ b/css/style.js
@@ -2,7 +2,6 @@ var style = {
   helpsContent: {
     display: 'flex',
     flexDirection: 'column',
-    flex: 'auto',
     backgroundColor: "var(--background-color-light)"
   },
   helpsHeader: {
@@ -14,7 +13,6 @@ var style = {
     borderBottom: '1px solid var(--border-color)',
   },
   helpsBody: {
-    flex: 'auto',
     overflowY: "auto",
     padding: '0 15px 30px',
   },


### PR DESCRIPTION
#### This pull request addresses:
This PR makes some changes to the flex properties in the tHelps modal to accommodate the minimum width for tC and window resizes.


#### How to test this pull request:
checkout the branches on tN, tW, and tHelps ```bugfix/jay/t-helps-resize/2512```
```cd tC_apps/TranslaitonHelps && git checkout bugfix/jay/t-helps-resize/2512```
```cd ../translationNotes && git checkout bugfix/jay/t-helps-resize/2512```
```cd ../translationWords && git checkout bugfix/jay/t-helps-resize/2512```
Open a tool in tC and ensure all the tHelps content is visible on window resize

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/translationcoreapps/translationhelps/47)
<!-- Reviewable:end -->
